### PR TITLE
Fact Checker: Add lxml-html-clean dependency

### DIFF
--- a/sonar-use-cases/fact_checker_cli/README.md
+++ b/sonar-use-cases/fact_checker_cli/README.md
@@ -17,7 +17,7 @@ A command-line tool that identifies false or misleading claims in articles or st
 
 ```bash
 # Ensure you are using the same pip associated with the python3 you intend to run the script with
-pip install requests pydantic newspaper3k
+pip install requests pydantic newspaper3k lxml-html-clean
 ```
 
 ### 2. Make the script executable


### PR DESCRIPTION
Updates the `pip install` in the README to include `lxml_html_clean` since it's now separate from `lxml`.

