### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/docs/examples/disease-qa/README.mdx
+++ b/docs/examples/disease-qa/README.mdx
@@ -9,7 +9,7 @@ keywords: [medical, health, webapp, interactive, diseases]
 
 An interactive browser-based application that provides structured information about diseases using Perplexity's Sonar API. This app generates a standalone HTML interface that allows users to ask questions about various diseases and receive organized responses with citations.
 
-![Disease Information App Screenshot](https://via.placeholder.com/800x450.png?text=Disease+Information+App)
+![Disease Information App Screenshot](https://placehold.co/800x450.png?text=Disease+Information+App)
 
 ## 🌟 Features
 


### PR DESCRIPTION
`docs/examples/disease-qa/README.mdx` references `via.placeholder.com/...` URLs. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Browsers render a broken-image icon in place of the intended placeholder.

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo 'connection refused / DNS gone'
```

#### What this PR changes

Fixes the screenshot placeholder in the Perplexity API cookbook's disease-qa example README so the screenshot renders when devs browse the cookbook.

#### Replacement details

`placehold.co` supports the identical `?text=` query param for captioned placeholders — drop-in match. Same 800×450 dimensions.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
