### PR TITLE
Add Equity Research Brief example (Agent API + finance_search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Ready-to-run applications demonstrating real-world use cases:
 - **[Daily Knowledge Bot](docs/examples/daily-knowledge-bot/)** - Automated daily fact delivery system  
 - **[Disease Information App](docs/examples/disease-qa/)** - Interactive medical information lookup
 - **[Financial News Tracker](docs/examples/financial-news-tracker/)** - Real-time market analysis
+- **[Equity Research Brief](docs/examples/equity-research-brief/)** - Agent API + `finance_search` for ticker-level research briefs
 - **[Academic Research Finder](docs/examples/research-finder/)** - Literature discovery and summarization
 - **[Discord Bot](docs/examples/discord-py-bot/)** - Discord integration example
 

--- a/docs/examples/README.mdx
+++ b/docs/examples/README.mdx
@@ -95,6 +95,26 @@ python financial_news_tracker.py "tech stocks"
 
 ---
 
+### 📈 [Equity Research Brief](equity-research-brief/)
+
+**Purpose**: Generate institutional-grade equity research briefs for any public ticker  
+**Type**: Command-line tool  
+**Use Cases**: Investor workflows, fundamental analysis, earnings prep, peer benchmarking  
+
+**Key Features**:
+- Uses the Agent API's built-in `finance_search` tool for structured fundamentals
+- Three preset configurations (live quote, single-company, multi-step research)
+- Cites Perplexity finance source URLs alongside the brief
+- Reports `finance_search` invocation count and total request cost
+
+**Quick Start**:
+```bash
+cd equity-research-brief/
+python equity_research_brief.py NVDA
+```
+
+---
+
 ### 📚 [Academic Research Finder](research-finder/)
 
 **Purpose**: Academic literature discovery and summarization  
@@ -150,6 +170,7 @@ Additional requirements vary by example and are listed in each `requirements.txt
 | Learn something new daily | **Daily Knowledge Bot** |
 | Look up medical information | **Disease Information App** |
 | Track financial markets | **Financial News Tracker** |
+| Generate an equity research brief | **Equity Research Brief** |
 | Research academic topics | **Academic Research Finder** |
 
 ## 🤝 Contributing

--- a/docs/examples/equity-research-brief/README.mdx
+++ b/docs/examples/equity-research-brief/README.mdx
@@ -1,0 +1,200 @@
+---
+title: Equity Research Brief
+description: Generate institutional-grade equity research briefs from any public ticker using the Perplexity Agent API and the built-in finance_search tool.
+sidebar_position: 7
+keywords: [agent-api, finance-search, equity-research, stocks, earnings, fundamentals, investment]
+---
+
+# Equity Research Brief
+
+A command-line tool that generates a structured equity research brief for any public ticker using Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) and the built-in [`finance_search`](https://docs.perplexity.ai/docs/agent-api/finance-search) tool.
+
+`finance_search` returns structured market data — quotes, financials, earnings transcripts, peer comparisons, analyst estimates — so the model can compose a report grounded in numbers, not just narrative. The tool is purpose-built for agentic investor workflows.
+
+## Features
+
+- One command produces a 6-section brief: snapshot, business overview, financial trajectory, latest earnings, peer context, risks, bottom line
+- Uses the Agent API's `finance_search` tool for structured fundamentals, quotes, and earnings-call transcripts
+- Three preset configurations matching the official `finance_search` recommendations:
+  - `quote` — live price/quote only, fastest and cheapest
+  - `single` — single-company historical lookup with web context
+  - `research` — full multi-step cross-company brief (default)
+- Prints citation-ready Perplexity finance source URLs alongside the brief
+- Reports `finance_search` invocation count and total request cost
+- `--json` flag emits the raw Agent API response for downstream pipelines
+
+## Prerequisites
+
+- Python 3.9+
+- A Perplexity API key with Agent API access. `finance_search` is currently in beta — see the [Finance Search docs](https://docs.perplexity.ai/docs/agent-api/finance-search) for availability.
+
+## Installation
+
+```bash
+cd docs/examples/equity-research-brief
+pip install -r requirements.txt
+chmod +x equity_research_brief.py
+```
+
+## API Key Setup
+
+```bash
+export PERPLEXITY_API_KEY="your-api-key-here"
+```
+
+You can also pass the key via `--api-key`, or place it in a `.pplx_api_key` file in the working directory.
+
+## Quick Start
+
+Generate a full research brief on NVIDIA:
+
+```bash
+./equity_research_brief.py NVDA
+```
+
+## Usage
+
+```bash
+./equity_research_brief.py TICKER [--config {quote,single,research}] [--json] [--api-key KEY]
+```
+
+### Just a live quote (cheapest, ~1 tool call)
+
+```bash
+./equity_research_brief.py AAPL --config quote
+```
+
+### Single-company historical lookup with web context
+
+```bash
+./equity_research_brief.py MSFT --config single
+```
+
+### Full multi-step research brief (default)
+
+```bash
+./equity_research_brief.py NVDA --config research
+```
+
+### Emit raw Agent API JSON
+
+```bash
+./equity_research_brief.py TSLA --json | jq '.usage.cost'
+```
+
+## Configuration Reference
+
+| Config     | Model                       | Tools                                     | Max steps | Best for                                  |
+| ---------- | --------------------------- | ----------------------------------------- | --------- | ----------------------------------------- |
+| `quote`    | `perplexity/sonar`          | `finance_search`                          | 1         | Live prices, quotes, fastest path         |
+| `single`   | `openai/gpt-5.5`            | `web_search` + `finance_search` + `fetch_url` | 5     | One-company historical fundamentals       |
+| `research` | `anthropic/claude-opus-4-7` | `web_search` + `finance_search` + `fetch_url` | 10    | Multi-company comparisons, full brief     |
+
+These configurations are taken directly from the [`finance_search` recommended configurations](https://docs.perplexity.ai/docs/agent-api/finance-search).
+
+## Example Output (truncated)
+
+```
+## 1. Snapshot
+
+- **Price:** $200.23 (as of 2026-05-01 14:10 UTC)
+- **Market cap:** $4.87T
+- **P/E (TTM):** 40.86
+- **52-week range:** $110.82 – $216.83
+
+## 2. Business overview
+
+NVIDIA designs accelerated computing platforms — GPUs, networking, and full-stack
+software — used in AI training and inference, gaming, professional visualization,
+and automotive. Data Center is the dominant revenue line.
+
+## 3. Financial trajectory
+| FY    | Revenue     | Operating margin | Net income |
+| ----- | ----------- | ---------------- | ---------- |
+| FY25  | $130.5B     | 62.4%            | $72.9B     |
+...
+
+---
+finance_search: 4 invocation(s) across categories [earnings_history, financials, profile, quote]
+
+Finance sources:
+  - https://www.perplexity.ai/finance/NVDA
+  - https://www.perplexity.ai/finance/NVDA/earnings?eventId=409967
+  - ...
+
+Cost: 0.2817 USD
+```
+
+## Code Walkthrough
+
+The script does three things:
+
+**1. Issue a single Agent API call with `finance_search` enabled.**
+
+```python
+from perplexity import Perplexity
+
+client = Perplexity()
+response = client.responses.create(
+    model="anthropic/claude-opus-4-7",
+    instructions=SYSTEM_PROMPT,
+    input=BRIEF_TEMPLATE.format(ticker="NVDA"),
+    tools=[
+        {"type": "web_search"},
+        {"type": "finance_search"},
+        {"type": "fetch_url"},
+    ],
+    max_output_tokens=4096,
+    max_steps=10,
+)
+```
+
+The model decides which `finance_search` categories to fetch (quote, financials, transcript, etc.) based on the prompt. You don't need to hand-pick fields.
+
+**2. Walk `response.output` to extract both the assistant text and the structured `finance_results` blocks.**
+
+```python
+for item in response.output:
+    if item.type == "finance_results":
+        for r in item.results:
+            print(r.category, r.tickers, r.sources)
+    elif item.type == "message":
+        for block in item.content:
+            if block.type == "output_text":
+                print(block.text)
+```
+
+**3. Surface cost and finance source URLs alongside the prose.** The Perplexity finance pages returned in `result.sources` are stable, citation-ready links — useful when the brief is consumed by humans or by a downstream RAG pipeline.
+
+## Prompting Guidance
+
+`finance_search` works best when the prompt asks for a business outcome, not for specific data shapes. The system prompt instructs the model to:
+
+- be quantitative and attribute numbers to the right period (e.g. `FY2025`, `Q3 FY26`)
+- never invent numbers — if `finance_search` doesn't return a field, say so explicitly
+- format the output in clean Markdown
+
+This pattern is documented in the [finance_search prompt guidance](https://docs.perplexity.ai/docs/agent-api/finance-search#prompt-guidance).
+
+## Pricing
+
+`finance_search` is billed at **$5 per 1,000 invocations**, separate from model token usage. Each preset has different cost characteristics:
+
+- `quote`: typically 1 invocation, ~$0.007 per brief
+- `single`: 1–3 invocations + GPT-5.5 tokens
+- `research`: 3–6 invocations + Claude Opus tokens
+
+See [Perplexity Pricing](https://docs.perplexity.ai/docs/getting-started/pricing) for current rates.
+
+## Limitations
+
+- `finance_search` is currently in beta and may not be enabled on all API keys
+- Results depend on Perplexity's finance data coverage; obscure or non-US tickers may return less structured data
+- This is not investment advice. The "Bottom line" section is explicitly framed as analytical opinion, not a recommendation
+
+## Resources
+
+- [Agent API Quickstart](https://docs.perplexity.ai/docs/agent-api/quickstart)
+- [Finance Search Tool](https://docs.perplexity.ai/docs/agent-api/finance-search)
+- [Agent API Tools Overview](https://docs.perplexity.ai/docs/agent-api/tools)
+- [Perplexity Python SDK](https://github.com/ppl-ai/perplexity-python)

--- a/docs/examples/equity-research-brief/equity_research_brief.py
+++ b/docs/examples/equity-research-brief/equity_research_brief.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Equity Research Brief - Generate a structured equity research brief for any
+public ticker using Perplexity's Agent API with the built-in ``finance_search``
+tool.
+
+The Agent API decides which finance categories to fetch (quotes, financials,
+earnings transcripts, peer comparisons, analyst estimates) based on the
+prompt. ``finance_search`` returns structured market data; the model then
+composes the final brief.
+
+Docs:
+- Agent API:        https://docs.perplexity.ai/docs/agent-api/quickstart
+- finance_search:   https://docs.perplexity.ai/docs/agent-api/finance-search
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from perplexity import Perplexity
+
+
+# ---------------------------------------------------------------------------
+# Recommended configurations from the finance_search docs.
+# Each preset maps to a different latency / cost / quality tradeoff.
+# ---------------------------------------------------------------------------
+CONFIGS: Dict[str, Dict[str, Any]] = {
+    "quote": {
+        # Live market data and quotes — fastest, cheapest.
+        "model": "perplexity/sonar",
+        "max_tokens": 1024,
+        "max_steps": 1,
+        "tools": [{"type": "finance_search"}],
+    },
+    "single": {
+        # Single-company historical lookups — adds web context.
+        "model": "openai/gpt-5.5",
+        "max_tokens": 2048,
+        "max_steps": 5,
+        "reasoning_effort": "low",
+        "tools": [
+            {"type": "web_search"},
+            {"type": "finance_search"},
+            {"type": "fetch_url"},
+        ],
+    },
+    "research": {
+        # Multi-step financial research — cross-company comparisons.
+        "model": "anthropic/claude-opus-4-7",
+        "max_tokens": 4096,
+        "max_steps": 10,
+        "tools": [
+            {"type": "web_search"},
+            {"type": "finance_search"},
+            {"type": "fetch_url"},
+        ],
+    },
+}
+
+
+SYSTEM_PROMPT = """You are an experienced equity research analyst writing a
+concise institutional-grade brief for a portfolio manager. Be specific and
+quantitative. When you cite numbers, attribute them to the relevant period
+(e.g. "FY2025", "Q3 FY26"). Never invent data: only use figures returned by
+finance_search or by the web. If a number is unavailable, say so explicitly.
+Format the final output in clean Markdown."""
+
+
+BRIEF_TEMPLATE = """Produce an equity research brief on {ticker}.
+
+Sections (in this order, all required):
+
+1. **Snapshot** — current price, market cap, P/E, 52-week range. Note the as-of
+   timestamp returned by finance_search.
+2. **Business overview** — 2-3 sentences on what the company does and its main
+   revenue lines.
+3. **Financial trajectory** — revenue, gross margin, operating margin, and net
+   income for the latest fiscal year and the two prior fiscal years. Comment on
+   trend.
+4. **Latest earnings** — most recent quarter: revenue and EPS actuals vs.
+   consensus, headline drivers, and any guidance changes from management
+   commentary.
+5. **Peer context** — pick 2 close peers and compare them on revenue growth and
+   operating margin for the latest fiscal year.
+6. **Risks** — 3 specific, current risks (cite source or earnings transcript).
+7. **Bottom line** — 2-sentence verdict, clearly labeled as analytical opinion,
+   not a recommendation.
+
+End with a "Sources" section listing the URLs returned in finance_search
+results and any web pages used."""
+
+
+def build_client(api_key: Optional[str] = None) -> Perplexity:
+    """Return an authenticated Perplexity client.
+
+    Looks up the key in this order: explicit argument, ``PERPLEXITY_API_KEY``,
+    ``PPLX_API_KEY``, then a ``.pplx_api_key`` / ``pplx_api_key`` file in the
+    working directory.
+    """
+    if not api_key:
+        api_key = os.environ.get("PERPLEXITY_API_KEY") or os.environ.get(
+            "PPLX_API_KEY"
+        )
+    if not api_key:
+        for candidate in (".pplx_api_key", "pplx_api_key"):
+            path = Path(candidate)
+            if path.exists():
+                api_key = path.read_text().strip()
+                break
+    if not api_key:
+        raise RuntimeError(
+            "API key not found. Set PERPLEXITY_API_KEY, pass --api-key, or "
+            "create a .pplx_api_key file."
+        )
+    return Perplexity(api_key=api_key)
+
+
+def generate_brief(
+    client: Perplexity,
+    ticker: str,
+    config_name: str = "research",
+) -> Any:
+    """Call the Agent API and return the raw response object."""
+    cfg = CONFIGS[config_name]
+    request: Dict[str, Any] = {
+        "model": cfg["model"],
+        "instructions": SYSTEM_PROMPT,
+        "input": BRIEF_TEMPLATE.format(ticker=ticker.upper()),
+        "tools": cfg["tools"],
+        "max_output_tokens": cfg["max_tokens"],
+    }
+    if "max_steps" in cfg:
+        request["max_steps"] = cfg["max_steps"]
+    if "reasoning_effort" in cfg:
+        request["reasoning"] = {"effort": cfg["reasoning_effort"]}
+    return client.responses.create(**request)
+
+
+# ---------------------------------------------------------------------------
+# Pretty-printing helpers
+# ---------------------------------------------------------------------------
+def _safe_output_text(response: Any) -> str:
+    """Concatenate every assistant text block in the response output.
+
+    The SDK's ``response.output_text`` helper assumes every output item is a
+    message with a ``.content`` list, but ``finance_results`` items don't
+    have ``.content``. Walk the output list defensively instead.
+    """
+    chunks: List[str] = []
+    for item in getattr(response, "output", []) or []:
+        item_type = getattr(item, "type", None) or (
+            item.get("type") if isinstance(item, dict) else None
+        )
+        if item_type != "message":
+            continue
+        content = (
+            getattr(item, "content", None)
+            if not isinstance(item, dict)
+            else item.get("content")
+        )
+        for block in content or []:
+            block_type = getattr(block, "type", None) or (
+                block.get("type") if isinstance(block, dict) else None
+            )
+            if block_type != "output_text":
+                continue
+            text = (
+                getattr(block, "text", None)
+                if not isinstance(block, dict)
+                else block.get("text")
+            )
+            if text:
+                chunks.append(text)
+    return "\n\n".join(chunks)
+
+
+def _collect_finance_results(response: Any) -> List[Dict[str, Any]]:
+    """Pull every ``finance_results`` item out of the response output."""
+    results: List[Dict[str, Any]] = []
+    for item in getattr(response, "output", []) or []:
+        item_type = getattr(item, "type", None) or (
+            item.get("type") if isinstance(item, dict) else None
+        )
+        if item_type != "finance_results":
+            continue
+        # SDK objects expose `.results`; dicts expose ["results"].
+        nested = (
+            getattr(item, "results", None)
+            if not isinstance(item, dict)
+            else item.get("results", [])
+        ) or []
+        for r in nested:
+            results.append(
+                r.model_dump() if hasattr(r, "model_dump") else r
+            )
+    return results
+
+
+def _collect_sources(finance_results: List[Dict[str, Any]]) -> List[str]:
+    seen: List[str] = []
+    for r in finance_results:
+        for url in r.get("sources", []) or []:
+            if url not in seen:
+                seen.append(url)
+    return seen
+
+
+def display(response: Any, format_json: bool = False) -> None:
+    """Render the response to stdout."""
+    if format_json:
+        # The SDK response object is Pydantic-like; fall back gracefully.
+        if hasattr(response, "model_dump"):
+            print(json.dumps(response.model_dump(), indent=2, default=str))
+        else:
+            print(json.dumps(response, indent=2, default=str))
+        return
+
+    finance_results = _collect_finance_results(response)
+    sources = _collect_sources(finance_results)
+
+    text = _safe_output_text(response)
+    if text:
+        print(text)
+
+    if finance_results:
+        categories = sorted(
+            {r.get("category", "") for r in finance_results if r.get("category")}
+        )
+        details = getattr(response.usage, "tool_calls_details", None)
+        finance_invocations = 0
+        if details is not None:
+            fs = (
+                details.get("finance_search")
+                if isinstance(details, dict)
+                else getattr(details, "finance_search", None)
+            )
+            if fs is not None:
+                finance_invocations = (
+                    fs.get("invocation", 0)
+                    if isinstance(fs, dict)
+                    else getattr(fs, "invocation", 0)
+                )
+        print("\n---")
+        print(
+            f"finance_search: {finance_invocations} invocation(s) "
+            f"across categories [{', '.join(categories)}]"
+        )
+
+    if sources:
+        print("\nFinance sources:")
+        for url in sources:
+            print(f"  - {url}")
+
+    cost = getattr(getattr(response, "usage", None), "cost", None)
+    if cost is not None:
+        if not isinstance(cost, dict):
+            cost = cost.model_dump() if hasattr(cost, "model_dump") else {}
+        total = cost.get("total_cost")
+        currency = cost.get("currency", "USD")
+        if total is not None:
+            print(f"\nCost: {total:.4f} {currency}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate an equity research brief using the Perplexity Agent "
+            "API and the finance_search tool."
+        )
+    )
+    parser.add_argument(
+        "ticker",
+        help="Ticker symbol or company name (e.g. NVDA, 'Microsoft').",
+    )
+    parser.add_argument(
+        "--config",
+        choices=sorted(CONFIGS.keys()),
+        default="research",
+        help=(
+            "Tool/model configuration: 'quote' (cheapest, live data only), "
+            "'single' (one company + web context), or 'research' (full "
+            "multi-step brief, default)."
+        ),
+    )
+    parser.add_argument(
+        "--api-key",
+        help="Perplexity API key (defaults to PERPLEXITY_API_KEY env var).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the raw Agent API response as JSON.",
+    )
+    args = parser.parse_args()
+
+    try:
+        client = build_client(args.api_key)
+    except RuntimeError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Generating {args.config} brief for {args.ticker.upper()}...",
+        file=sys.stderr,
+    )
+    try:
+        response = generate_brief(client, args.ticker, args.config)
+    except Exception as err:  # noqa: BLE001
+        print(f"Agent API error: {err}", file=sys.stderr)
+        return 2
+
+    display(response, format_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/examples/equity-research-brief/requirements.txt
+++ b/docs/examples/equity-research-brief/requirements.txt
@@ -1,0 +1,1 @@
+perplexityai>=0.6.0


### PR DESCRIPTION
## Summary

Adds a new cookbook example that demonstrates the **Agent API**'s built-in **`finance_search`** tool. Generates a structured equity research brief (snapshot, fundamentals, latest earnings, peer context, risks, bottom line) for any public ticker.

None of the existing examples use the Agent API or `finance_search` — the closest, `financial-news-tracker`, only calls Sonar chat completions for news narrative. This fills a real gap in coverage.

## What's added

- `docs/examples/equity-research-brief/equity_research_brief.py` — CLI tool
- `docs/examples/equity-research-brief/README.mdx` — example doc, `sidebar_position: 7`
- `docs/examples/equity-research-brief/requirements.txt` — `perplexityai>=0.6.0`

Updates `README.md` and `docs/examples/README.mdx` to register the new example.

## Configurations

Three preset configurations match the [official `finance_search` recommendations](https://docs.perplexity.ai/docs/agent-api/finance-search):

| Config | Model | Tools | Max steps | Best for |
|---|---|---|---|---|
| `quote` | `perplexity/sonar` | `finance_search` | 1 | Live quote, fastest path |
| `single` | `openai/gpt-5.5` | `web_search` + `finance_search` + `fetch_url` | 5 | Single-company historical lookup |
| `research` | `anthropic/claude-opus-4-7` | `web_search` + `finance_search` + `fetch_url` | 10 | Multi-step cross-company brief |

## Verification

Smoke-tested against the live API on `NVDA`. `finance_search` invoked across `quote`, `profile`, and `earnings_history` categories. Cost reported at ~$0.01 for the `quote` config; sources surfaced as Perplexity finance URLs.

## Notes

- `finance_search` is currently in beta — example README links to the docs and notes the availability constraint.
- The script defensively walks `response.output` rather than relying on `response.output_text`, since responses include `finance_results` items that the SDK helper doesn't handle.
