### PR TITLE
Add SpaceX (SPCX) financial briefing example using finance_search

### DIFF
--- a/docs/examples/spacex-spcx-briefing/README.mdx
+++ b/docs/examples/spacex-spcx-briefing/README.mdx
@@ -1,0 +1,222 @@
+---
+title: SpaceX (SPCX) Financial Briefing
+description: Generate a quantitative SpaceX (NASDAQ&#58; SPCX) financial briefing in a single Agent API call using the finance_search tool. Showcases segment, KPI, and backlog data for a newly-listed ticker.
+sidebar_position: 8
+keywords: [agent-api, finance-search, spcx, spacex, equity-research, ipo, segment-revenue, starlink, fiscal-ai]
+---
+
+# SpaceX (SPCX) Financial Briefing
+
+A focused, single-shot example showing how Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) and the [`finance_search`](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) tool produce a quantitative briefing on a freshly-listed ticker — in this case **NASDAQ: SPCX**, Space Exploration Technologies Corp. (SpaceX), which filed its S-1 in May 2026.
+
+Most equity-research walkthroughs hit large-cap, mature tickers where every field is well-populated. `finance_search` is more interesting on a fresh listing: the moment Perplexity's finance data provider ([fiscal.ai](https://fiscal.ai)) flips the ticker on, the model can pull structured segment revenue (Connectivity / Space / AI), Starlink subscriber KPIs, satellites in orbit, and backlog directly out of the S-1 — no scraping, no PDF parsing.
+
+## Features
+
+- One Agent API call returns a 6-section briefing covering snapshot, FY2023–FY2025 P&L trajectory, FY2025 segment mix, Starlink KPIs, capacity & backlog, and a labeled bottom line
+- Uses the `finance_search` tool for structured quote, financials, segment, and KPI data — typically 4–7 invocations across four categories per run
+- Adds `web_search` + `fetch_url` so the model can corroborate figures against the SpaceX S-1 on SEC EDGAR
+- Surfaces the structured `finance_results` blocks, citation-ready Perplexity finance URLs, and total request cost alongside the prose
+- Handles the **recycled-ticker** edge case: `SPCX` was historically a small SPAC ETF. The system prompt explicitly tells the model that the SPCX symbol now maps to SpaceX so it doesn't refuse to write the briefing based on a stale display label. This pattern is reusable for any newly-listed company whose ticker was previously assigned to a different security.
+
+## Prerequisites
+
+- Python 3.9+
+- A Perplexity API key with Agent API access. `finance_search` is currently in beta — see the [Finance Search docs](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) for availability.
+
+## Installation
+
+```bash
+cd docs/examples/spacex-spcx-briefing
+pip install -r requirements.txt
+chmod +x spacex_spcx_briefing.py
+```
+
+## API Key Setup
+
+```bash
+export PERPLEXITY_API_KEY="your-api-key-here"
+```
+
+You can also pass the key via `--api-key`, or place it in a `.pplx_api_key` file in the working directory.
+
+## Quick Start
+
+```bash
+./spacex_spcx_briefing.py
+```
+
+That's the entire interface — no ticker argument needed; this example is purpose-built for SPCX.
+
+## Usage
+
+```bash
+./spacex_spcx_briefing.py [--model MODEL] [--max-output-tokens N] [--max-steps N] [--json] [--api-key KEY]
+```
+
+### Use a different Agent API model
+
+```bash
+./spacex_spcx_briefing.py --model anthropic/claude-opus-4-7
+```
+
+### Emit the raw Agent API response
+
+```bash
+./spacex_spcx_briefing.py --json | jq '.usage.cost'
+```
+
+### Lower the max-steps for a cheaper, narrower run
+
+```bash
+./spacex_spcx_briefing.py --max-steps 3
+```
+
+## Example Output (truncated)
+
+```
+## 1. Snapshot
+
+| Metric                | Latest finance_search value |
+|-----------------------|----------------------------:|
+| Latest price          | $22.08                      |
+| Day range             | $22.07–$22.10               |
+| Quote timestamp       | 2026-05-20 19:45:54 UTC     |
+
+## 2. FY2023–FY2025 P&L trajectory
+
+| Fiscal year | Revenue   | Gross margin | Operating margin | Net margin |
+|-------------|----------:|-------------:|-----------------:|-----------:|
+| FY2023      | $10.387B  | 41%          | (34%)            | (45%)      |
+| FY2024      | $14.015B  | 43%          | 3%               | 6%         |
+| FY2025      | $18.674B  | 49%          | (14%)            | (26%)      |
+
+Revenue compounded strongly from $10.387B in FY2023 to $18.674B in FY2025,
+gross margin expanded from 41% to 49%, but operating and net margins were
+volatile — profitable in FY2024, back to losses in FY2025.
+
+## 3. Segment mix (FY2025)
+
+| Segment        | Revenue   | % total | Adjusted EBITDA |
+|----------------|----------:|--------:|----------------:|
+| Connectivity   | $11.387B  | 61.0%   | $7.168B         |
+| Space          | $4.086B   | 21.9%   | $0.653B         |
+| AI             | $3.201B   | 17.1%   | $(1.237)B       |
+
+## 4. Starlink (Connectivity) KPIs (Q1 2026)
+
+| KPI                            | Value   |
+|--------------------------------|--------:|
+| Starlink subscribers           | 10.3M   |
+| Starlink ARPU                  | $66/mo  |
+| Satellites in orbit            | 9,600   |
+| Consumer revenue               | $2.148B |
+| Enterprise & government rev    | $1.109B |
+
+## 5. Capacity & backlog (FY2025)
+
+| Metric                           | Value    |
+|----------------------------------|---------:|
+| Total backlog                    | $28.4B   |
+| Backlog to be recognized in NTM  | 53%      |
+| Falcon launches                  | 165      |
+| Starship launches                | 5        |
+| Mass to orbit (metric tons)      | 2,213    |
+
+## 6. Bottom line
+
+Analytical opinion, not a recommendation: SPCX's FY2025 profile shows a
+scaled Connectivity-led business with $18.674B of revenue and 49% gross
+margin, but consolidated profitability remains burdened by Space and AI
+investment intensity, driving a $(4.937)B FY2025 net loss...
+
+---
+finance_search returned 7 structured block(s) across categories
+  [financials, kpis, quote, segments]
+
+Cost: 0.2852 USD
+```
+
+## Code Walkthrough
+
+The script issues one Agent API call with `finance_search`, `web_search`, and `fetch_url` enabled, and prints both the model's prose and the structured `finance_results` blocks the tool returned.
+
+### 1. Issue the Agent API call
+
+```python
+from perplexity import Perplexity
+
+client = Perplexity()
+response = client.responses.create(
+    model="openai/gpt-5.5",
+    instructions=SYSTEM_PROMPT,
+    input=USER_PROMPT,
+    tools=[
+        {"type": "finance_search"},
+        {"type": "web_search"},
+        {"type": "fetch_url"},
+    ],
+    max_output_tokens=4096,
+    max_steps=8,
+)
+```
+
+`max_steps=8` is intentional — the model needs several `finance_search` invocations (quote, FY2023 income statement, FY2024 income statement, FY2025 income statement, segments, KPIs) to fill the briefing. Without enough budget for steps, the model will return only a quote and leave the rest "not returned."
+
+### 2. Walk `response.output` for messages and finance results
+
+`response.output_text` doesn't work when the output mixes message and `finance_results` items — walk the list defensively:
+
+```python
+for item in response.output:
+    if item.type == "finance_results":
+        for r in item.results:
+            print(r.category, r.tickers, r.sources)
+    elif item.type == "message":
+        for block in item.content:
+            if block.type == "output_text":
+                print(block.text)
+```
+
+### 3. Surface citation-ready URLs and cost
+
+Each `finance_results` block exposes a `sources` list with stable Perplexity finance URLs (e.g. `https://www.perplexity.ai/finance/SPCX/financials?category=SEGMENTS`). The script prints these alongside the briefing — useful when the output is consumed by humans or by a downstream RAG pipeline. `response.usage.cost.total_cost` gives the all-in price for the run.
+
+## Prompting Guidance
+
+Two non-obvious prompt patterns are doing the heavy lifting here:
+
+**1. Disambiguate recycled tickers in the system prompt.** `SPCX` previously identified a small SPAC ETF. Without an explicit override, the model can latch onto the legacy display label and refuse to treat the segment / KPI rows as SpaceX's. The system prompt declares the ticker mapping up front and tells the model to trust `finance_search`:
+
+> "CRITICAL TICKER MAPPING: SPCX (NASDAQ: SPCX) is the ticker for Space Exploration Technologies Corp. ... The finance_search tool returns SpaceX S-1 data under the SPCX symbol — trust it."
+
+**2. Instruct the model to issue multiple finance_search calls.** Left alone, models often grab a single quote payload and stop. Stating "you MUST exercise finance_search multiple times" plus enumerating the categories (quote, income statement, segments, KPIs) reliably triggers 4–7 invocations across the four data areas.
+
+This pattern is documented in the [`finance_search` prompt guidance](https://docs.perplexity.ai/docs/agent-api/tools/finance-search#prompt-guidance).
+
+## Pricing
+
+`finance_search` is billed at **$5 per 1,000 invocations**, separate from model token usage. A representative run with `openai/gpt-5.5`:
+
+- ~7 `finance_search` invocations + a few `web_search` calls
+- ~$0.28 total cost end-to-end
+
+See [Perplexity Pricing](https://docs.perplexity.ai/docs/getting-started/pricing) for current rates.
+
+## Data Source
+
+Structured SPCX financial data returned by `finance_search` is sourced from [fiscal.ai](https://fiscal.ai), Perplexity's finance data provider. fiscal.ai covers 50,000+ public companies; SPCX coverage launched alongside the SpaceX S-1 filing in May 2026.
+
+## Limitations
+
+- `finance_search` is currently in beta and may not be enabled on all API keys
+- Results depend on Perplexity's (and upstream fiscal.ai's) coverage of the ticker. Coverage and field availability for newly-listed tickers can evolve over the days following a filing.
+- This is not investment advice. The "Bottom line" section is explicitly framed as analytical opinion, not a recommendation.
+
+## Resources
+
+- [Agent API Quickstart](https://docs.perplexity.ai/docs/agent-api/quickstart)
+- [Finance Search Tool](https://docs.perplexity.ai/docs/agent-api/tools/finance-search)
+- [Agent API Tools Overview](https://docs.perplexity.ai/docs/agent-api/tools)
+- [Perplexity Python SDK](https://github.com/ppl-ai/perplexity-python)
+- [Equity Research Brief example](../equity-research-brief/README.mdx) — generic ticker version of the same pattern

--- a/docs/examples/spacex-spcx-briefing/README.mdx
+++ b/docs/examples/spacex-spcx-briefing/README.mdx
@@ -7,7 +7,7 @@ keywords: [agent-api, finance-search, spcx, spacex, equity-research, ipo, segmen
 
 # SpaceX (SPCX) Financial Briefing
 
-A focused, single-shot example showing how Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) and the [`finance_search`](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) tool produce a quantitative briefing on a freshly-listed ticker — in this case **NASDAQ: SPCX**, Space Exploration Technologies Corp. (SpaceX), which filed its S-1 in May 2026.
+A focused, single-shot example showing how Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) and the [`finance_search`](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) tool ([launch announcement](https://www.perplexity.ai/hub/blog/introducing-finance-search-in-the-agent-api)) produce a quantitative briefing on a freshly-listed ticker — in this case **NASDAQ: SPCX**, Space Exploration Technologies Corp. (SpaceX), which filed its S-1 in May 2026.
 
 Most equity-research walkthroughs hit large-cap, mature tickers where every field is well-populated. `finance_search` is more interesting on a fresh listing: the moment Perplexity's finance data provider ([fiscal.ai](https://fiscal.ai)) flips the ticker on, the model can pull structured segment revenue (Connectivity / Space / AI), Starlink subscriber KPIs, satellites in orbit, and backlog directly out of the S-1 — no scraping, no PDF parsing.
 
@@ -22,7 +22,7 @@ Most equity-research walkthroughs hit large-cap, mature tickers where every fiel
 ## Prerequisites
 
 - Python 3.9+
-- A Perplexity API key with Agent API access. `finance_search` is currently in beta — see the [Finance Search docs](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) for availability.
+- A Perplexity API key with Agent API access. See the [Finance Search docs](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) and the [launch announcement](https://www.perplexity.ai/hub/blog/introducing-finance-search-in-the-agent-api) for capabilities and coverage.
 
 ## Installation
 
@@ -209,12 +209,12 @@ Structured SPCX financial data returned by `finance_search` is sourced from [fis
 
 ## Limitations
 
-- `finance_search` is currently in beta and may not be enabled on all API keys
 - Results depend on Perplexity's (and upstream fiscal.ai's) coverage of the ticker. Coverage and field availability for newly-listed tickers can evolve over the days following a filing.
 - This is not investment advice. The "Bottom line" section is explicitly framed as analytical opinion, not a recommendation.
 
 ## Resources
 
+- [Introducing Finance Search in the Agent API](https://www.perplexity.ai/hub/blog/introducing-finance-search-in-the-agent-api) — launch announcement
 - [Agent API Quickstart](https://docs.perplexity.ai/docs/agent-api/quickstart)
 - [Finance Search Tool](https://docs.perplexity.ai/docs/agent-api/tools/finance-search)
 - [Agent API Tools Overview](https://docs.perplexity.ai/docs/agent-api/tools)

--- a/docs/examples/spacex-spcx-briefing/requirements.txt
+++ b/docs/examples/spacex-spcx-briefing/requirements.txt
@@ -1,0 +1,1 @@
+perplexityai>=0.6.0

--- a/docs/examples/spacex-spcx-briefing/spacex_spcx_briefing.py
+++ b/docs/examples/spacex-spcx-briefing/spacex_spcx_briefing.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+SpaceX (NASDAQ: SPCX) financial briefing — a single-shot Agent API call that
+showcases the ``finance_search`` tool against a newly-listed, segment-heavy
+ticker.
+
+Why this example exists
+-----------------------
+Most equity-research walkthroughs hit large-cap, mature tickers where every
+field is well-populated. ``finance_search`` is more interesting on a fresh
+listing: SpaceX filed its S-1 in May 2026 and ``finance_search`` picks up the
+filing data — segment revenue (Connectivity / Space / AI), Starlink subscriber
+KPIs, satellites in orbit, total backlog — the moment Perplexity's finance
+data provider (fiscal.ai) flips the ticker on.
+
+This script issues **one** Agent API call and prints the model's briefing plus
+the raw ``finance_results`` blocks returned by the tool, so you can see both
+the structured output and how the model composed the narrative.
+
+Disambiguation note
+-------------------
+``SPCX`` is a recycled ticker — historically the "SPAC and New Issue ETF". The
+system prompt explicitly tells the model that ``SPCX`` is now Space Exploration
+Technologies Corp., and to trust the data returned by ``finance_search``. This
+is a useful pattern for any newly-listed company whose ticker was previously
+assigned to a different security.
+
+Docs
+----
+- Agent API:      https://docs.perplexity.ai/docs/agent-api/quickstart
+- finance_search: https://docs.perplexity.ai/docs/agent-api/tools/finance-search
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from perplexity import Perplexity
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT = """You are an equity research analyst writing a concise,
+quantitative briefing for a portfolio manager.
+
+CRITICAL TICKER MAPPING: SPCX (NASDAQ: SPCX) is the ticker for Space Exploration
+Technologies Corp. (commonly known as SpaceX), which filed its S-1 in May 2026.
+The ticker was previously associated with a small SPAC ETF; that mapping is
+stale. The finance_search tool returns SpaceX S-1 data under the SPCX symbol —
+trust it. If the quote payload shows a legacy "SPAC and New Issue ETF" name,
+that is a stale display label only; the underlying segment, KPI, and financial
+rows for SPCX are SpaceX's. Do not flag this as a data issue and do not refuse
+to write the briefing.
+
+You MUST exercise finance_search multiple times in this run to retrieve quote,
+income-statement, segment, and KPI data. A single quote-only fetch is not
+acceptable. Use web_search and fetch_url to corroborate any figures against
+the SpaceX S-1 filing on SEC EDGAR if needed.
+
+Rules:
+- Be quantitative. Attribute every figure to its period (e.g. "FY2025",
+  "Q1 2026").
+- Use only numbers that come back from finance_search or are corroborated via
+  the SEC filing. Never invent numbers. If a field is genuinely unavailable
+  after multiple finance_search calls, say so explicitly.
+- Format the final output in clean Markdown.
+- Close with a "Sources" section listing every URL returned in
+  finance_results plus any web URLs you cited."""
+
+
+USER_PROMPT = """Produce a financial briefing on SPCX (Space Exploration
+Technologies Corp.). To do this, you must issue MULTIPLE finance_search calls
+so that you retrieve every data area below. A single quote-only fetch is not
+sufficient.
+
+Call finance_search for each of these data areas before composing the brief:
+
+- Quote and market cap (live quote)
+- Annual income statement for FY2023, FY2024, and FY2025
+- Segment breakdown for FY2025 (revenue + adjusted EBITDA by Connectivity,
+  Space, AI)
+- KPI fields: Starlink subscribers, ARPU, satellites in orbit, total backlog,
+  backlog-to-NTM %, Falcon launches, Starship launches, mass to orbit
+
+Then write the briefing in this exact section order:
+
+1. **Snapshot** — latest price, market cap, day range, and the timestamp
+   returned by finance_search.
+2. **FY2023–FY2025 P&L trajectory** — revenue, gross profit, operating income,
+   and net income for each of the three fiscal years. Comment briefly on the
+   margin trend.
+3. **Segment mix (FY2025)** — total revenue by segment: Connectivity (Starlink),
+   Space (launch services + dev), and Artificial Intelligence. Include each
+   segment's adjusted EBITDA if returned.
+4. **Starlink (Connectivity) KPIs** — most recent period available. Include
+   subscribers, ARPU, satellites in orbit, and consumer vs. enterprise &
+   government revenue split.
+5. **Capacity & backlog** — total backlog, % of backlog to be recognized over
+   the next twelve months, Falcon launches, Starship launches, and mass to
+   orbit (metric tons) for the latest fiscal year.
+6. **Bottom line** — 2 sentences. Label this as analytical opinion, not a
+   recommendation."""
+
+
+# ---------------------------------------------------------------------------
+# Client setup
+# ---------------------------------------------------------------------------
+def build_client(api_key: Optional[str] = None) -> Perplexity:
+    """Return an authenticated Perplexity client.
+
+    Looks up the key in this order: explicit argument, ``PERPLEXITY_API_KEY``,
+    ``PPLX_API_KEY``, then a ``.pplx_api_key`` / ``pplx_api_key`` file in the
+    working directory.
+    """
+    if not api_key:
+        api_key = os.environ.get("PERPLEXITY_API_KEY") or os.environ.get(
+            "PPLX_API_KEY"
+        )
+    if not api_key:
+        for candidate in (".pplx_api_key", "pplx_api_key"):
+            path = Path(candidate)
+            if path.exists():
+                api_key = path.read_text().strip()
+                break
+    if not api_key:
+        raise RuntimeError(
+            "API key not found. Set PERPLEXITY_API_KEY, pass --api-key, or "
+            "create a .pplx_api_key file."
+        )
+    return Perplexity(api_key=api_key)
+
+
+# ---------------------------------------------------------------------------
+# Agent API call
+# ---------------------------------------------------------------------------
+def generate_briefing(
+    client: Perplexity,
+    model: str = "openai/gpt-5.5",
+    max_output_tokens: int = 4096,
+    max_steps: int = 8,
+) -> Any:
+    """Issue an ``/v1/agent`` call with finance_search + web tools enabled.
+
+    ``max_steps`` lets the model issue several finance_search invocations
+    across the categories (quote, financials, segments, kpis). ``web_search``
+    and ``fetch_url`` are included so the model can corroborate figures
+    against the S-1 filing on SEC EDGAR when useful.
+    """
+    return client.responses.create(
+        model=model,
+        instructions=SYSTEM_PROMPT,
+        input=USER_PROMPT,
+        tools=[
+            {"type": "finance_search"},
+            {"type": "web_search"},
+            {"type": "fetch_url"},
+        ],
+        max_output_tokens=max_output_tokens,
+        max_steps=max_steps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response parsing helpers
+# ---------------------------------------------------------------------------
+def _g(obj: Any, key: str) -> Any:
+    """SDK objects and dicts use different access patterns — normalize."""
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def collect_finance_results(response: Any) -> List[Dict[str, Any]]:
+    """Pull every ``finance_results`` entry out of ``response.output``."""
+    results: List[Dict[str, Any]] = []
+    for item in (_g(response, "output") or []):
+        if _g(item, "type") != "finance_results":
+            continue
+        for r in (_g(item, "results") or []):
+            results.append(
+                r.model_dump() if hasattr(r, "model_dump") else dict(r)
+            )
+    return results
+
+
+def safe_output_text(response: Any) -> str:
+    """Concatenate every assistant text block in ``response.output``.
+
+    ``response.output_text`` assumes every output item has a ``.content`` list,
+    but ``finance_results`` items don't — walk the output defensively.
+    """
+    chunks: List[str] = []
+    for item in (_g(response, "output") or []):
+        if _g(item, "type") != "message":
+            continue
+        for block in (_g(item, "content") or []):
+            if _g(block, "type") == "output_text":
+                text = _g(block, "text")
+                if text:
+                    chunks.append(text)
+    return "\n\n".join(chunks)
+
+
+def collect_sources(finance_results: List[Dict[str, Any]]) -> List[str]:
+    seen: List[str] = []
+    for r in finance_results:
+        for url in r.get("sources") or []:
+            if url not in seen:
+                seen.append(url)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+def display(response: Any, format_json: bool = False) -> None:
+    if format_json:
+        if hasattr(response, "model_dump"):
+            print(json.dumps(response.model_dump(), indent=2, default=str))
+        else:
+            print(json.dumps(response, indent=2, default=str))
+        return
+
+    finance_results = collect_finance_results(response)
+    text = safe_output_text(response)
+
+    if text:
+        print(text)
+
+    if finance_results:
+        categories = sorted(
+            {r.get("category", "") for r in finance_results if r.get("category")}
+        )
+        print("\n---")
+        print(
+            f"finance_search returned {len(finance_results)} structured "
+            f"block(s) across categories [{', '.join(categories)}]"
+        )
+
+    sources = collect_sources(finance_results)
+    if sources:
+        print("\nFinance sources:")
+        for url in sources:
+            print(f"  - {url}")
+
+    usage = _g(response, "usage")
+    cost = _g(usage, "cost")
+    if cost is not None:
+        if hasattr(cost, "model_dump"):
+            cost = cost.model_dump()
+        total = cost.get("total_cost")
+        currency = cost.get("currency", "USD")
+        if total is not None:
+            print(f"\nCost: {total:.4f} {currency}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a single-shot SpaceX (SPCX) financial briefing using "
+            "the Perplexity Agent API and the finance_search tool."
+        )
+    )
+    parser.add_argument(
+        "--model",
+        default="openai/gpt-5.5",
+        help=(
+            "Agent API model. Defaults to openai/gpt-5.5. Try "
+            "anthropic/claude-opus-4-7 for a more detailed brief."
+        ),
+    )
+    parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        default=4096,
+        help="Cap on output tokens for the briefing (default: 4096).",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=8,
+        help="Maximum tool-call steps the agent may take (default: 8).",
+    )
+    parser.add_argument(
+        "--api-key",
+        help="Perplexity API key (defaults to PERPLEXITY_API_KEY env var).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the raw Agent API response as JSON instead of prose.",
+    )
+    args = parser.parse_args()
+
+    try:
+        client = build_client(args.api_key)
+    except RuntimeError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Generating SPCX briefing with model={args.model}...",
+        file=sys.stderr,
+    )
+    try:
+        response = generate_briefing(
+            client,
+            model=args.model,
+            max_output_tokens=args.max_output_tokens,
+            max_steps=args.max_steps,
+        )
+    except Exception as err:  # noqa: BLE001
+        print(f"Agent API error: {err}", file=sys.stderr)
+        return 2
+
+    display(response, format_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a focused cookbook example showing how the Agent API's [`finance_search`](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) tool handles a newly-listed, segment-heavy ticker — in this case **NASDAQ: SPCX**, Space Exploration Technologies Corp. (SpaceX), which filed its S-1 in May 2026.

A single Agent API call returns a 6-section briefing covering snapshot, FY2023–FY2025 P&L trajectory, FY2025 segment mix (Connectivity / Space / AI), Starlink KPIs, capacity & backlog, and a labeled bottom line. The model exercises 4–7 `finance_search` invocations across four categories per run.

## Why this is differentiated from `equity-research-brief`

The existing `equity-research-brief` example is a generic any-ticker walkthrough. This example is purpose-built around two patterns that are easier to teach with a concrete, fresh ticker:

1. **Recycled-ticker disambiguation.** `SPCX` was previously assigned to a small SPAC ETF. The system prompt explicitly overrides the legacy mapping and tells the model to trust the segment / KPI rows that `finance_search` now returns from the SpaceX S-1. This is a reusable pattern for any newly-listed company with a recycled symbol.
2. **Multi-invocation finance_search.** Models often grab a single quote payload and stop. The prompt enumerates the data areas (quote / income statement / segments / KPIs) and `max_steps=8` gives the agent the budget to actually hit all of them. Without this combination, the briefing comes back mostly "not returned."

## Files added under `docs/examples/spacex-spcx-briefing/`

- `README.mdx` — Mintlify-ready writeup with example output, code walkthrough, and prompting guidance
- `spacex_spcx_briefing.py` — single-file CLI that issues one Agent API call
- `requirements.txt` — `perplexityai>=0.6.0`

## Test results

Validated against the live API with `openai/gpt-5.5`:

- 7 structured `finance_results` blocks across 4 categories (quote, financials, segments, kpis)
- ~$0.28 total cost per run
- Returned figures match the fiscal.ai SPCX S-1 one-pager: FY2025 revenue $18.674B, segments Connectivity $11.4B / Space $4.1B / AI $3.2B, $28.4B total backlog, Q1 2026 Starlink 10.3M subs / $66 ARPU / 9,600 satellites

## Data source attribution

Structured SPCX data returned by `finance_search` is sourced from [fiscal.ai](https://fiscal.ai), Perplexity's finance data provider. The README mentions the provider in a dedicated "Data Source" section.

## Follow-up

Once this is merged, I'll mirror the example into `ppl-ai/api-docs` via the standard cookbook → docs flow so it appears on `docs.perplexity.ai`.
