### PR TITLE
Fix

### DIFF
--- a/docs/examples/spacex-spcx-briefing/README.mdx
+++ b/docs/examples/spacex-spcx-briefing/README.mdx
@@ -2,14 +2,14 @@
 title: SpaceX (SPCX) Financial Briefing
 description: Generate a quantitative SpaceX (NASDAQ&#58; SPCX) financial briefing in a single Agent API call using the finance_search tool. Showcases segment, KPI, and backlog data for a newly-listed ticker.
 sidebar_position: 8
-keywords: [agent-api, finance-search, spcx, spacex, equity-research, ipo, segment-revenue, starlink, fiscal-ai]
+keywords: [agent-api, finance-search, spcx, spacex, equity-research, ipo, segment-revenue, starlink]
 ---
 
 # SpaceX (SPCX) Financial Briefing
 
 A focused, single-shot example showing how Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) and the [`finance_search`](https://docs.perplexity.ai/docs/agent-api/tools/finance-search) tool ([launch announcement](https://www.perplexity.ai/hub/blog/introducing-finance-search-in-the-agent-api)) produce a quantitative briefing on a freshly-listed ticker — in this case **NASDAQ: SPCX**, Space Exploration Technologies Corp. (SpaceX), which filed its S-1 in May 2026.
 
-Most equity-research walkthroughs hit large-cap, mature tickers where every field is well-populated. `finance_search` is more interesting on a fresh listing: the moment Perplexity's finance data provider ([fiscal.ai](https://fiscal.ai)) flips the ticker on, the model can pull structured segment revenue (Connectivity / Space / AI), Starlink subscriber KPIs, satellites in orbit, and backlog directly out of the S-1 — no scraping, no PDF parsing.
+Most equity-research walkthroughs hit large-cap, mature tickers where every field is well-populated. `finance_search` is more interesting on a fresh listing: the moment Perplexity's finance data provider flips the ticker on, the model can pull structured segment revenue (Connectivity / Space / AI), Starlink subscriber KPIs, satellites in orbit, and backlog directly out of the S-1 — no scraping, no PDF parsing.
 
 ## Features
 
@@ -85,7 +85,7 @@ That's the entire interface — no ticker argument needed; this example is purpo
 
 ## 2. FY2023–FY2025 P&L trajectory
 
-| Fiscal year | Revenue   | Gross margin | Operating margin | Net margin |
+| Reporting year | Revenue   | Gross margin | Operating margin | Net margin |
 |-------------|----------:|-------------:|-----------------:|-----------:|
 | FY2023      | $10.387B  | 41%          | (34%)            | (45%)      |
 | FY2024      | $14.015B  | 43%          | 3%               | 6%         |
@@ -205,11 +205,11 @@ See [Perplexity Pricing](https://docs.perplexity.ai/docs/getting-started/pricing
 
 ## Data Source
 
-Structured SPCX financial data returned by `finance_search` is sourced from [fiscal.ai](https://fiscal.ai), Perplexity's finance data provider. fiscal.ai covers 50,000+ public companies; SPCX coverage launched alongside the SpaceX S-1 filing in May 2026.
+Structured SPCX financial data returned by `finance_search` comes from Perplexity's finance data provider. SPCX coverage launched alongside the SpaceX S-1 filing in May 2026.
 
 ## Limitations
 
-- Results depend on Perplexity's (and upstream fiscal.ai's) coverage of the ticker. Coverage and field availability for newly-listed tickers can evolve over the days following a filing.
+- Results depend on Perplexity's upstream coverage of the ticker. Coverage and field availability for newly-listed tickers can evolve over the days following a filing.
 - This is not investment advice. The "Bottom line" section is explicitly framed as analytical opinion, not a recommendation.
 
 ## Resources

--- a/docs/examples/spacex-spcx-briefing/spacex_spcx_briefing.py
+++ b/docs/examples/spacex-spcx-briefing/spacex_spcx_briefing.py
@@ -11,7 +11,7 @@ field is well-populated. ``finance_search`` is more interesting on a fresh
 listing: SpaceX filed its S-1 in May 2026 and ``finance_search`` picks up the
 filing data — segment revenue (Connectivity / Space / AI), Starlink subscriber
 KPIs, satellites in orbit, total backlog — the moment Perplexity's finance
-data provider (fiscal.ai) flips the ticker on.
+data provider flips the ticker on.
 
 This script issues **one** Agent API call and prints the model's briefing plus
 the raw ``finance_results`` blocks returned by the tool, so you can see both
@@ -93,7 +93,7 @@ Then write the briefing in this exact section order:
 1. **Snapshot** — latest price, market cap, day range, and the timestamp
    returned by finance_search.
 2. **FY2023–FY2025 P&L trajectory** — revenue, gross profit, operating income,
-   and net income for each of the three fiscal years. Comment briefly on the
+   and net income for each of the three reported years. Comment briefly on the
    margin trend.
 3. **Segment mix (FY2025)** — total revenue by segment: Connectivity (Starlink),
    Space (launch services + dev), and Artificial Intelligence. Include each
@@ -103,7 +103,7 @@ Then write the briefing in this exact section order:
    government revenue split.
 5. **Capacity & backlog** — total backlog, % of backlog to be recognized over
    the next twelve months, Falcon launches, Starship launches, and mass to
-   orbit (metric tons) for the latest fiscal year.
+   orbit (metric tons) for the latest reported year.
 6. **Bottom line** — 2 sentences. Label this as analytical opinion, not a
    recommendation."""
 


### PR DESCRIPTION
## Description
Remove provider-specific and generic `fiscal` wording from the SpaceX SPCX briefing cookbook example.

## Type of Contribution
- [ ] Example Tutorial
- [ ] Showcase Project
- [ ] Article/Integration Guide
- [x] Documentation Update
- [ ] Bug Fix
- [ ] Other (please describe)

## Checklist
- [x] My code follows the cookbook's style guidelines
- [x] I have included comprehensive documentation
- [x] I have tested my code and it works as expected
- [x] I have included all necessary dependencies and setup instructions
- [x] My MDX file includes proper frontmatter (title, description, keywords)
- [x] I have linked to any external repositories or live demos

## Project Details
**What problem does this solve?**
Removes mentions of `fiscal` from the SpaceX briefing README and companion script prompts/docstring.

**What makes this contribution valuable to other developers?**
Keeps the cookbook example focused on Perplexity finance search behavior without naming the upstream provider or using the removed terminology.

**External Links (if applicable):**
- GitHub Repository: N/A
- Live Demo: N/A
- Blog Post/Article: N/A

## Testing
- `git diff --check`
- `grep -RInIi "fiscal" docs/examples/spacex-spcx-briefing` (no matches)
- `/workspace/build/buildkite/bin/node scripts/validate-mdx.js`
- `python3 -m py_compile docs/examples/spacex-spcx-briefing/spacex_spcx_briefing.py`

## Screenshots (if applicable)
N/A

## Additional Notes
N/A

---
🤖 _Generated by [PSI](https://www.notion.so/perplexity-ai/HowTo-PSI-Perplexity-Super-Intelligence-29c6172b229b80d3a8ece89a6cfb6ae6)_
🧠 _Agent used: `codex`_
