### PR TITLE
Change 'Reporting year' to 'Fiscal year' in SpaceX briefing

### DIFF
--- a/docs/examples/spacex-spcx-briefing/README.mdx
+++ b/docs/examples/spacex-spcx-briefing/README.mdx
@@ -85,7 +85,7 @@ That's the entire interface — no ticker argument needed; this example is purpo
 
 ## 2. FY2023–FY2025 P&L trajectory
 
-| Reporting year | Revenue   | Gross margin | Operating margin | Net margin |
+| Fiscal year    | Revenue   | Gross margin | Operating margin | Net margin |
 |-------------|----------:|-------------:|-----------------:|-----------:|
 | FY2023      | $10.387B  | 41%          | (34%)            | (45%)      |
 | FY2024      | $14.015B  | 43%          | 3%               | 6%         |


### PR DESCRIPTION
Renames the P&L trajectory table column header from "Reporting year" to "Fiscal year" in `docs/examples/spacex-spcx-briefing/README.mdx` for consistency with the FY-labeled rows.