### PR TITLE
fix: replace dead via.placeholder.com cookbook image (#66)

### DIFF
--- a/docs/examples/disease-qa/README.mdx
+++ b/docs/examples/disease-qa/README.mdx
@@ -9,7 +9,7 @@ keywords: [medical, health, webapp, interactive, diseases]
 
 An interactive browser-based application that provides structured information about diseases using Perplexity's Sonar API. This app generates a standalone HTML interface that allows users to ask questions about various diseases and receive organized responses with citations.
 
-![Disease Information App Screenshot](https://via.placeholder.com/800x450.png?text=Disease+Information+App)
+![Disease Information App Screenshot](./disease-qa-screenshot.svg)
 
 ## 🌟 Features
 

--- a/docs/examples/disease-qa/disease-qa-screenshot.svg
+++ b/docs/examples/disease-qa/disease-qa-screenshot.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450" role="img" aria-label="Disease Information App screenshot placeholder">
+  <rect width="800" height="450" fill="#0f172a"/>
+  <rect x="40" y="40" width="720" height="370" rx="16" fill="#1e293b" stroke="#38bdf8" stroke-width="2"/>
+  <text x="400" y="210" fill="#e2e8f0" font-family="system-ui, sans-serif" font-size="28" text-anchor="middle">Disease Q&amp;A Tutorial App</text>
+  <text x="400" y="250" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="16" text-anchor="middle">Perplexity API cookbook example</text>
+</svg>


### PR DESCRIPTION
## Summary

Fixes #66 — disease-qa README referenced `via.placeholder.com`, which is connection-refused.

## Fix

Replace with bundled `disease-qa-screenshot.svg` beside the README.

## Verification

Open `docs/examples/disease-qa/README.mdx` and confirm image renders from `./disease-qa-screenshot.svg`.